### PR TITLE
Add name input field to FTP and SFTP configurations

### DIFF
--- a/ftp.html
+++ b/ftp.html
@@ -16,6 +16,10 @@
 
 <script type="text/x-red" data-template-name="ftp">
   <div class="form-row">
+    <label for="node-config-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>
+    <input type="text" id="node-config-input-name">
+  </div>
+  <div class="form-row">
     <label for="node-config-input-host"><i class="fa fa-bookmark"></i> <span data-i18n="ftp.label.host"></span></label>
     <input type="text" id="node-config-input-host" placeholder="localhost" style="width: 40%;" />
     <label for="node-config-input-port" style="margin-left: 10px; width: 35px; "> <span data-i18n="ftp.label.port"></span></label>
@@ -120,6 +124,7 @@
     category: 'config',
     color:"BurlyWood",
     defaults: {
+      name: { value: '' },
       host: { value: '' },
       port: { value: '' },
       secure: { value: false },
@@ -133,7 +138,7 @@
       password: { type: 'password', required: true },
     },
     label: function() {
-      return this.host
+      return this.name || this.host;
     }
   });
 </script>

--- a/ftp.js
+++ b/ftp.js
@@ -23,6 +23,7 @@
     RED.nodes.createNode(this, n);
     var node = this;
     var credentials = RED.nodes.getCredentials(n.id);
+    this.name = n.name;
     this.options = {
       'host': n.host || 'localhost',
       'port': n.port || 21,

--- a/sftp.html
+++ b/sftp.html
@@ -15,6 +15,10 @@
 -->
 
 <script type="text/x-red" data-template-name="sftp">
+  <div class="form-row">
+    <label for="node-config-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>
+    <input type="text" id="node-config-input-name">
+  </div>
   <div class="form-row" style="margin-bottom: 0px;">
     <label for="node-config-input-host"><i class="fa fa-bookmark"></i> <span data-i18n="sftp.label.host"></span></label>
     <input type="text" id="node-config-input-host" placeholder="localhost" style="width: 40%;" />
@@ -85,6 +89,7 @@
     category: 'config',
     color:"BurlyWood",
     defaults: {
+      name: { value: '' },
       host: { value: '' },
       port: { value: '' },
       forceIPv4: { value: false },
@@ -104,7 +109,7 @@
       agent: { type: 'text' }
     },
     label: function() {
-      return this.host
+      return this.name || this.host;
     },
     oneditprepare: function() {
       var that = this;

--- a/sftp.js
+++ b/sftp.js
@@ -23,6 +23,7 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, n);
     var node = this;
     var credentials = RED.nodes.getCredentials(n.id);
+    this.name = n.name;
     this.options = {
       'host': n.host || 'localhost',
       'port': n.port || 22,


### PR DESCRIPTION
I want to make FTP nodes more intuitive by allowing users to assign a recognizable name to each FTP connection. A new name attribute has been added; by default, the displayed value remains the IP address. If the user specifies a name, it will be shown instead.






